### PR TITLE
Fix development mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ Run the app with
 docker-compose -f docker-compose.yml -f docker-compose.prod.yml up --build
 ```
 
-or in development mode (hot reloading when source code changes) with
+or in development mode (mounts the source code into the container so that
+changes are reflected) with
 
 ```sh
 docker-compose -f docker-compose.yml -f docker-compose.dev.yml up --build

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,4 +1,4 @@
-version: "3.7"
+version: '3.7'
 
 services:
   redis:
@@ -9,9 +9,7 @@ services:
     ports:
       - 8000:8000
     volumes:
-      - type: bind
-        source: ./backend
-        target: /checkers/backend
+      - ./backend:/checkers/backend
   frontend:
     build:
       target: build
@@ -21,6 +19,5 @@ services:
     ports:
       - 80:9000
     volumes:
-      - type: bind
-        source: ./frontend
-        target: /checkers/frontend
+      - ./frontend/public:/checkers/frontend/public
+      - ./frontend/src:/checkers/frontend/src

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -2,10 +2,10 @@
 FROM node:14-alpine as build
 ARG CHECKERS_BACKEND="localhost:8000"
 WORKDIR /checkers/frontend
-ENV PATH /checkers/frontend/node_modules/.bin:$PATH
 COPY package* ./
 RUN npm ci --silent
 COPY . ./
+ENV PATH /checkers/frontend/node_modules/.bin:$PATH
 RUN CHECKERS_BACKEND=${CHECKERS_BACKEND} npm run build
 
 FROM nginx:alpine


### PR DESCRIPTION
Fixes: #2 

I was mounting the entire `frontend` directory into the container which would overwrite `node_modules` installed by the container. If user hadn't installed locally previously this would result in an error, if they had then they would not realise that `webpack-dev-server` was being run from the user's local installation rather than something installed in the container.