### PR TITLE
Ensure players are enumerated consistently

### DIFF
--- a/frontend/src/stores.js
+++ b/frontend/src/stores.js
@@ -3,7 +3,7 @@ import { writable } from "svelte/store";
 function createBoardStore() {
   const { subscribe, update } = writable({
     time: 0,
-    player: 0,
+    player: 1,
     counters: null,
     history: [],
     active: { row: null, col: null },
@@ -25,7 +25,7 @@ function createBoardStore() {
         ...board,
         active: { row: null, col: null },
         time,
-        player: 1 - player,
+        player: 3 - player,
         counters: history[time],
       };
     }
@@ -42,7 +42,7 @@ function createBoardStore() {
         ...board,
         active: { row: null, col: null },
         time,
-        player: 1 - player,
+        player: 3 - player,
         counters: history[time],
       };
     }


### PR DESCRIPTION
Fixes: #1 

Probably when looking at the history the `Player ${player}'s turn` display shouldn't really change, but that would be more work to address.